### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ ./build_ios.sh
 
 ### Requirements
 
-* XCode 7 or after version
+* Xcode 7 or after version
 
     Note, use xcode 4 SDK won't support some command
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/
Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
